### PR TITLE
Fix #6 - Bot now disallows commands to start with non-alphanumeric ch…

### DIFF
--- a/source/ArnoBot.FrontEnd.DiscordBot/MessageHandler.cs
+++ b/source/ArnoBot.FrontEnd.DiscordBot/MessageHandler.cs
@@ -173,7 +173,10 @@ namespace ArnoBot.FrontEnd.DiscordBot
             if(prefixes.Any((prefix) => message.Content.StartsWith(selectedPrefix = prefix)))
             {
                 triggerInfo = new TriggerInfo(selectedPrefix, false);
-                return true;
+                string prefixCutMessage = message.Content.Remove(0, selectedPrefix.Length);
+
+                // Bot should ignore messages that start with a prefix followed by non-alphanumeric characters.
+                return prefixCutMessage.Length > 0 && char.IsLetterOrDigit(prefixCutMessage[0]);
             }
             else if(listenToMentions && MessageStartsWithBotMention(message))
             {

--- a/source/ArnoBot/Interface/CommandRegistry.cs
+++ b/source/ArnoBot/Interface/CommandRegistry.cs
@@ -7,9 +7,21 @@ namespace ArnoBot.Interface
 {
     public class CommandRegistry : IDictionary<string, ICommand>, IReadOnlyCommandRegistry
     {
+        private const string ARGUMENT_INVALID_EX_MSG = "A command key must start with an alphanumeric character and can not be empty.";
+
         private Dictionary<string, ICommand> internalDictionary = new Dictionary<string, ICommand>();
 
-        public ICommand this[string key] { get => internalDictionary[key.ToLower()]; set => internalDictionary[key.ToLower()] = value; }
+        public ICommand this[string key]
+        {
+            get => internalDictionary[key.ToLower()];
+            set
+            {
+                if (IsValidKey(key))
+                    internalDictionary[key.ToLower()] = value;
+                else
+                    throw new ArgumentException(ARGUMENT_INVALID_EX_MSG);
+            }
+        }
 
         public ICollection<string> Keys => internalDictionary.Keys;
 
@@ -24,7 +36,12 @@ namespace ArnoBot.Interface
         IEnumerable<ICommand> IReadOnlyDictionary<string, ICommand>.Values => (internalDictionary as IReadOnlyDictionary<string, ICommand>).Values;
 
         public void Add(string key, ICommand value)
-            => internalDictionary.Add(key.ToLower(), value);
+        {
+            if (IsValidKey(key))
+                internalDictionary.Add(key.ToLower(), value);
+            else
+                throw new ArgumentException(ARGUMENT_INVALID_EX_MSG);
+        }
 
         public void Add(KeyValuePair<string, ICommand> item)
             => Add(item.Key, item.Value);
@@ -55,6 +72,12 @@ namespace ArnoBot.Interface
 
         IEnumerator IEnumerable.GetEnumerator()
             => (internalDictionary as IEnumerable).GetEnumerator();
+
+        private bool IsValidKey(string key)
+        {
+            return key.Length > 0
+                && char.IsLetterOrDigit(key[0]);
+        }
     }
 
     public interface IReadOnlyCommandRegistry : IReadOnlyDictionary<string, ICommand>


### PR DESCRIPTION
…aracters and triggers starting with a prefix followed by non-alphanumeric characters are now ignored by the discord integration.